### PR TITLE
修复了HttpRequest.cs中HttpRequest(Stream stream) GET请求的参数获取错误

### DIFF
--- a/HTTPServer/HTTPServerLib/HttpRequest.cs
+++ b/HTTPServer/HTTPServerLib/HttpRequest.cs
@@ -65,8 +65,8 @@ namespace HTTPServerLib
             if (this.Method == "GET")
             {
                 this.Body = GetRequestBody(rows);
-                var isUrlencoded = this.URL.Contains('?');
-                if (isUrlencoded) this.Params = GetRequestParameters(URL.Split('?')[1]);
+                var isUrlencoded = first[1].Contains('?');
+                if (isUrlencoded) this.Params = GetRequestParameters(first[1].Split('?')[1]);
             }
 
             //Request "POST"


### PR DESCRIPTION
HttpRequest.cs文件的第68、69行，处理GET的地址中的参数时，不应该用URL变量，应该用first[1]。否则无法解析出参数。